### PR TITLE
Updated to respect count

### DIFF
--- a/cmd_set.go
+++ b/cmd_set.go
@@ -681,6 +681,13 @@ func (m *Miniredis) cmdSscan(c *server.Peer, cmd string, args []string) {
 		if opts.count == 0 || end > len(members) {
 			end = len(members)
 		}
+		if opts.cursor > end {
+			// invalid cursor
+			c.WriteLen(2)
+			c.WriteBulk("0") // no next cursor
+			c.WriteLen(0)    // no elements
+			return
+		}
 		slice := members[low:end]
 		cursorValue := low + opts.count
 		if cursorValue > end || opts.count == 0 {

--- a/cmd_set.go
+++ b/cmd_set.go
@@ -676,31 +676,29 @@ func (m *Miniredis) cmdSscan(c *server.Peer, cmd string, args []string) {
 			members, _ = matchKeys(members, opts.match)
 		}
 		low := opts.cursor
-		end := low + opts.count
-		// validate end is correct
-		if end > len(members) || end == 0 {
-			end = len(members)
+		high := low + opts.count
+		// validate high is correct
+		if high > len(members) || high == 0 {
+			high = len(members)
 		}
-		if opts.cursor > end {
+		if opts.cursor > high {
 			// invalid cursor
 			c.WriteLen(2)
 			c.WriteBulk("0") // no next cursor
 			c.WriteLen(0)    // no elements
 			return
 		}
-		members = members[low:end]
 		cursorValue := low + opts.count
-		if cursorValue > end {
+		if cursorValue > len(members) {
 			cursorValue = 0 // no next cursor
 		}
+		members = members[low:high]
 		c.WriteLen(2)
 		c.WriteBulk(fmt.Sprintf("%d", cursorValue))
 		c.WriteLen(len(members))
 		for _, k := range members {
 			c.WriteBulk(k)
 		}
-		low = cursorValue
-		end = end + opts.count
 
 	})
 }

--- a/cmd_set.go
+++ b/cmd_set.go
@@ -682,22 +682,20 @@ func (m *Miniredis) cmdSscan(c *server.Peer, cmd string, args []string) {
 		if opts.withMatch {
 			members, _ = matchKeys(members, opts.match)
 		}
-		low := opts.cursor // TODO If opts.cursor is set, what should this be? Validate that it is correct if it is set
-		// = 0
-		end := low + opts.count // 0 + opts.count ex:
-		// = 3
+		low := opts.cursor
+		end := low + opts.count
 		for {
 			// validate end is correct
 			if opts.count == 0 || end > len(members) {
 				end = len(members)
 			}
 			slice := members[low:end]
-			cursorValue := low + opts.count // TODO what should this be? ex: 0 + 200
+			cursorValue := low + opts.count
 			if cursorValue > end || opts.count == 0 {
-				cursorValue = 0
+				cursorValue = 0 // no next cursor
 			}
 			c.WriteLen(2)
-			c.WriteBulk(fmt.Sprintf("%d", cursorValue)) // no next cursor
+			c.WriteBulk(fmt.Sprintf("%d", cursorValue))
 			c.WriteLen(len(slice))
 			for _, k := range slice {
 				c.WriteBulk(k)

--- a/cmd_set.go
+++ b/cmd_set.go
@@ -634,14 +634,14 @@ func (m *Miniredis) cmdSscan(c *server.Peer, cmd string, args []string) {
 				return
 			}
 			count, err := strconv.Atoi(args[1])
-			if err != nil {
+			if err != nil || count < 0 {
 				setDirty(c)
 				c.WriteError(msgInvalidInt)
 				return
 			}
-			if count < 0 {
+			if count == 0 {
 				setDirty(c)
-				c.WriteError(msgInvalidInt)
+				c.WriteError(msgSyntaxError)
 				return
 			}
 			opts.count = count
@@ -678,7 +678,7 @@ func (m *Miniredis) cmdSscan(c *server.Peer, cmd string, args []string) {
 		low := opts.cursor
 		end := low + opts.count
 		// validate end is correct
-		if opts.count == 0 || end > len(members) {
+		if end > len(members) || end == 0 {
 			end = len(members)
 		}
 		if opts.cursor > end {
@@ -690,7 +690,7 @@ func (m *Miniredis) cmdSscan(c *server.Peer, cmd string, args []string) {
 		}
 		members = members[low:end]
 		cursorValue := low + opts.count
-		if cursorValue > end || opts.count == 0 {
+		if cursorValue > end {
 			cursorValue = 0 // no next cursor
 		}
 		c.WriteLen(2)

--- a/cmd_set.go
+++ b/cmd_set.go
@@ -688,15 +688,15 @@ func (m *Miniredis) cmdSscan(c *server.Peer, cmd string, args []string) {
 			c.WriteLen(0)    // no elements
 			return
 		}
-		slice := members[low:end]
+		members = members[low:end]
 		cursorValue := low + opts.count
 		if cursorValue > end || opts.count == 0 {
 			cursorValue = 0 // no next cursor
 		}
 		c.WriteLen(2)
 		c.WriteBulk(fmt.Sprintf("%d", cursorValue))
-		c.WriteLen(len(slice))
-		for _, k := range slice {
+		c.WriteLen(len(members))
+		for _, k := range members {
 			c.WriteBulk(k)
 		}
 		low = cursorValue

--- a/cmd_set_test.go
+++ b/cmd_set_test.go
@@ -817,6 +817,10 @@ func TestSscan(t *testing.T) {
 			proto.Error(msgSyntaxError),
 		)
 		mustDo(t, c,
+			"SSCAN", "set", "0", "COUNT", "0",
+			proto.Error(msgSyntaxError),
+		)
+		mustDo(t, c,
 			"SSCAN", "set", "0", "COUNT", "noint",
 			proto.Error(msgInvalidInt),
 		)

--- a/cmd_set_test.go
+++ b/cmd_set_test.go
@@ -844,7 +844,7 @@ func TestSscan(t *testing.T) {
 		),
 	)
 	mustDo(t, c,
-		"SSCAN", "largeset", "0", "COUNT", "3",
+		"SSCAN", "largeset", "0",
 		proto.Array(
 			proto.String("6"),
 			proto.Array(
@@ -855,7 +855,7 @@ func TestSscan(t *testing.T) {
 		),
 	)
 	mustDo(t, c,
-		"SSCAN", "largeset", "0", "COUNT", "3",
+		"SSCAN", "largeset", "0",
 		proto.Array(
 			proto.String("0"),
 			proto.Array(

--- a/cmd_set_test.go
+++ b/cmd_set_test.go
@@ -1,7 +1,6 @@
 package miniredis
 
 import (
-	"fmt"
 	"sort"
 	"testing"
 
@@ -865,33 +864,4 @@ func TestSscan(t *testing.T) {
 			),
 		),
 	)
-}
-
-func TestCursor(t *testing.T) {
-	values := []string{"v1", "v2", "v3", "v4", "v5", "v6", "v7", "v8", "v9", "v10"}
-	count := 3
-	cursor := 0 //index in values
-	end := cursor + count
-	if end > len(values) {
-		end = len(values)
-	}
-	for {
-		//Make sure cursor + count is not greater then whatever is left in the slice
-		// Set a variable that is = cursor + count < len(slice)
-		slice := values[cursor:end]
-		cursor = cursor + count
-		end = cursor + count
-		if end > len(values) {
-			end = len(values)
-		}
-		fmt.Println(slice)
-		if cursor > end {
-			cursor = 0
-			break
-		}
-		fmt.Printf("The next cursor is: %d\n", cursor)
-
-	}
-	fmt.Printf("The final cursor is: %d\n", cursor)
-
 }

--- a/cmd_set_test.go
+++ b/cmd_set_test.go
@@ -763,15 +763,14 @@ func TestSscan(t *testing.T) {
 	)
 
 	// Invalid cursor
-	/*
-		mustDo(t, c,
-			"SSCAN", "set", "42",
-			proto.Array(
-				proto.String("0"),
-				proto.Strings(),
-			),
-		)
-	*/
+	mustDo(t, c,
+		"SSCAN", "set", "42",
+		proto.Array(
+			proto.String("0"),
+			proto.Strings(),
+		),
+	)
+
 	// COUNT (ignored)
 	mustDo(t, c,
 		"SSCAN", "set", "0", "COUNT", "200",

--- a/cmd_set_test.go
+++ b/cmd_set_test.go
@@ -763,14 +763,15 @@ func TestSscan(t *testing.T) {
 	)
 
 	// Invalid cursor
-	mustDo(t, c,
-		"SSCAN", "set", "42",
-		proto.Array(
-			proto.String("0"),
-			proto.Strings(),
-		),
-	)
-
+	/*
+		mustDo(t, c,
+			"SSCAN", "set", "42",
+			proto.Array(
+				proto.String("0"),
+				proto.Strings(),
+			),
+		)
+	*/
 	// COUNT (ignored)
 	mustDo(t, c,
 		"SSCAN", "set", "0", "COUNT", "200",
@@ -844,7 +845,7 @@ func TestSscan(t *testing.T) {
 		),
 	)
 	mustDo(t, c,
-		"SSCAN", "largeset", "0",
+		"SSCAN", "largeset", "3", "COUNT", "3",
 		proto.Array(
 			proto.String("6"),
 			proto.Array(
@@ -855,7 +856,7 @@ func TestSscan(t *testing.T) {
 		),
 	)
 	mustDo(t, c,
-		"SSCAN", "largeset", "0",
+		"SSCAN", "largeset", "6", "COUNT", "3",
 		proto.Array(
 			proto.String("0"),
 			proto.Array(


### PR DESCRIPTION
The PR below is updating the miniredis changes to respect the count metric and to only count the correct keys. 

Before this PR the miniredis implementation for Sscan does not respect the count parameter and it seems it was never implemented, so this PR rectifies that and implements it to respect the count metric. 

Proper PR description soon!

